### PR TITLE
Added a llink to the forum thread

### DIFF
--- a/client/src/addon.xml
+++ b/client/src/addon.xml
@@ -14,5 +14,8 @@
     <description lang="en">A modern web interface for KODI. Browse all your movies, tv shows and musics. See what's currently playing. Discover new movies and tv shows. All from your browser, desktop or tablets.</description>
     <platform>all</platform>
     <language>en</language>
+    <license>The MIT License (MIT)</license>
+    <forum>http://forum.kodi.tv/showthread.php?tid=224515</forum>
+    <source>https://github.com/abricot/webinterface.arch</source>
   </extension>
 </addon>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
